### PR TITLE
Fix: 사고가시화 도구 로딩 문제 해결

### DIFF
--- a/assets/js/tools-loader-v2.js
+++ b/assets/js/tools-loader-v2.js
@@ -8,7 +8,15 @@ document.addEventListener('DOMContentLoaded', async function() {
         
         try {
             console.log('도구 데이터를 불러오는 중...');
-            const response = await fetch('data/tools-v2.json');
+            
+            // GitHub Pages를 위한 경로 수정
+            const basePath = window.location.pathname.includes('/edu-thinking-toolkit') 
+                ? '/edu-thinking-toolkit' 
+                : '';
+            const dataUrl = `${basePath}/data/tools-v2.json`;
+            
+            console.log('데이터 URL:', dataUrl);
+            const response = await fetch(dataUrl);
             
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## 문제 해결
웹페이지에서 사고가시화 도구가 표시되지 않는 문제를 수정했습니다.

### 변경 사항
- `tools-loader-v2.js`에서 데이터 파일 경로를 GitHub Pages 환경에 맞게 수정
- 상대 경로 `data/tools-v2.json`을 동적으로 처리하도록 변경
- GitHub Pages URL 구조를 자동으로 감지하여 올바른 경로 설정

### 수정 내용
```javascript
// 기존
const response = await fetch('data/tools-v2.json');

// 수정
const basePath = window.location.pathname.includes('/edu-thinking-toolkit') 
    ? '/edu-thinking-toolkit' 
    : '';
const dataUrl = `${basePath}/data/tools-v2.json`;
const response = await fetch(dataUrl);
```

이제 https://plusiam.github.io/edu-thinking-toolkit/index-v2.html 에서 도구들이 정상적으로 표시됩니다.